### PR TITLE
Truncate error message avoiding CookieOverflowError

### DIFF
--- a/lib/active_admin_import/dsl.rb
+++ b/lib/active_admin_import/dsl.rb
@@ -76,7 +76,8 @@ module ActiveAdminImport
             instance_exec result, options, &DEFAULT_RESULT_PROC
           end
         rescue ActiveRecord::Import::MissingColumnError, NoMethodError, ActiveRecord::StatementInvalid => e
-          flash[:error] = I18n.t('active_admin_import.file_error', message: e.message)
+          Rails.logger.error(I18n.t('active_admin_import.file_error', message: e.message))
+          flash[:error] = I18n.t('active_admin_import.file_error', message: e.message[0..200])
         end
         redirect_to options[:back]
       end


### PR DESCRIPTION
The error message can be huge, which can result in a ActionDispatch::Cookies::CookieOverflow. Truncate the flash message and output the whole error to the logs.