### PR TITLE
failed messages && zh-CN.yml && batch transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ And then execute:
   <li> Replacements/Updates support</li>
   <li> Encoding handling</li>
   <li> CSV options</li>
-  <li> Ability to descibe/change CSV headers</li>
+  <li> Ability to describe/change CSV headers</li>
   <li> Bulk import (activerecord-import)</li>
   <li> Callbacks</li>
   <li> Zip files</li>
@@ -94,7 +94,7 @@ Tool                  | Description
 [activerecord-import] | Powerful library for bulk inserting data using ActiveRecord.
 
 [rchardet]: https://github.com/jmhodges/rchardet
-[activerecord-import]: https://github.com/jmhodges/rchardet
+[activerecord-import]: https://github.com/zdennis/activerecord-import
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Tool                    | Description
 :csv_options			|hash with column separator, row separator, etc 
 :validate				|bool means perform validations or not
 :batch_size				|integer value of max  record count inserted by 1 query/transaction
+:batch_transaction    |bool, if batch import using transaction, false by default
 :before_import			|proc for before import action, hook called with  importer object
 :after_import			|proc for after import action, hook called with  importer object
 :before_batch_import	|proc for before each batch action, called with  importer object

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,7 @@ en:
   active_admin:
     import: "Import"
   active_admin_import:
+    file: 'File'
     file_error: "Error: %{message}"
     file_format_error: "You can import only valid csv file"
     file_empty_error: "You can't import empty file"
@@ -16,3 +17,7 @@ en:
     import_model: "Import %{plural_model}"
     import_btn: "Import"
     import_btn_disabled: "Wait..."
+    csv_options: "CSV options"
+    col_sep: 'Col sep'
+    row_sep: 'Row sep'
+    quote_char: 'Quote char'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,8 +11,8 @@ en:
       one: "Successfully imported 1 %{model}"
       other: "Successfully imported %{count} %{plural_model}"
     failed:
-      one:   "Failed to import 1 %{model}"
-      other: "Failed to import %{count} %{plural_model}"
+      one:   "Failed to import 1 %{model}: %{message}"
+      other: "Failed to import %{count} %{plural_model}: %{message}"
     import_model: "Import %{plural_model}"
     import_btn: "Import"
     import_btn_disabled: "Wait..."

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -1,0 +1,19 @@
+zh-CN:
+  active_admin:
+    import: "导入"
+    do_import: "导入"
+  active_admin_import:
+    file_error: "导入错误: %{message}"
+    file_format_error: "请您上传 CSV 格式的文件"
+    file_empty_error: "您上传的文件为空"
+    no_file_error: "请您选择要上传的文件"
+    details: "请您选择要上传的文件"
+    imported:
+      one: "成功导入 1 份%{model}"
+      other: "成功导入 %{count} 份%{plural_model}"
+    failed:
+      one:   "未能导入 1 份%{model}: %{message}"
+      other: "未能导入 %{count} 份%{plural_model}: %{message}"
+    import_model: "导入%{plural_model}"
+    import_btn: "导入"
+    import_btn_disabled: "请稍等..."

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -3,6 +3,7 @@ zh-CN:
     import: "导入"
     do_import: "导入"
   active_admin_import:
+    file: '文件'
     file_error: "导入错误: %{message}"
     file_format_error: "请您上传 CSV 格式的文件"
     file_empty_error: "您上传的文件为空"
@@ -17,3 +18,7 @@ zh-CN:
     import_model: "导入%{plural_model}"
     import_btn: "导入"
     import_btn_disabled: "请稍等..."
+    csv_options: "选项"
+    col_sep: '列分隔符'
+    row_sep: '行分隔符'
+    quote_char: '引用字符'

--- a/lib/active_admin_import/dsl.rb
+++ b/lib/active_admin_import/dsl.rb
@@ -35,7 +35,7 @@ module ActiveAdminImport
           flash[:notice] = I18n.t('active_admin_import.imported', count: result.imported_qty, model: model_name, plural_model: plural_model_name)
         end
         if result.has_failed?
-          flash[:error] = I18n.t('active_admin_import.failed', count: result.failed.count, model: model_name, plural_model: plural_model_name)
+          flash[:error] = I18n.t('active_admin_import.failed', count: result.failed.count, model: model_name, plural_model: plural_model_name, message: result.failed_message)
         end
       end
     end

--- a/lib/active_admin_import/dsl.rb
+++ b/lib/active_admin_import/dsl.rb
@@ -8,6 +8,7 @@ module ActiveAdminImport
     # +back+:: resource action to redirect after processing
     # +csv_options+:: hash to override default CSV options
     # +batch_size+:: integer value of max  record count inserted by 1 query/transaction
+    # +batch_transaction+:: bool, if batch import using transaction, false by default
     # +before_import+:: proc for before import action, hook called with  importer object
     # +after_import+:: proc for after import action, hook called with  importer object
     # +before_batch_import+:: proc for before each batch action, called with  importer object
@@ -31,11 +32,12 @@ module ActiveAdminImport
       if result.empty?
         flash[:warning] = I18n.t('active_admin_import.file_empty_error')
       else
-        if result.has_imported?
-          flash[:notice] = I18n.t('active_admin_import.imported', count: result.imported_qty, model: model_name, plural_model: plural_model_name)
-        end
         if result.has_failed?
           flash[:error] = I18n.t('active_admin_import.failed', count: result.failed.count, model: model_name, plural_model: plural_model_name, message: result.failed_message)
+          return if options[:batch_transaction]
+        end
+        if result.has_imported?
+          flash[:notice] = I18n.t('active_admin_import.imported', count: result.imported_qty, model: model_name, plural_model: plural_model_name)
         end
       end
     end

--- a/lib/active_admin_import/import_result.rb
+++ b/lib/active_admin_import/import_result.rb
@@ -8,18 +8,18 @@ module ActiveAdminImport
     end
 
     def add(result, qty)
-       @failed += result.failed_instances
-       @total+=qty
+      @failed += result.failed_instances
+      @total+=qty
     end
-        
+
     def imported_qty
       total - failed.count
-    end 
-    
+    end
+
     def has_imported?
       imported_qty > 0
     end
-    
+
     def has_failed?
       @failed.any?
     end
@@ -28,5 +28,11 @@ module ActiveAdminImport
       total == 0
     end
 
+    def failed_message
+      failed.map{|record|
+        errors = record.errors
+        (errors.full_messages.zip errors.keys.map{|k| record.send k}).map{|ms| ms.join(' - ')}.join(', ')
+      }.join(" ; ")
+    end
   end
 end

--- a/lib/active_admin_import/options.rb
+++ b/lib/active_admin_import/options.rb
@@ -6,6 +6,7 @@ module ActiveAdminImport
         :csv_options,
         :validate,
         :batch_size,
+        :batch_transaction,
         :before_import,
         :after_import,
         :before_batch_import,


### PR DESCRIPTION
Hi, Fivell

I'm making a project using *activeadmin*, and  *active_admin_import* really helps me a lot. Thanks so much for the convenience. And here are some issuese I've met, hope to help.

First, after installing the gem, I've got confused about where is the entrance. I hope there is a specification about the authorization of `Cancan` or `Pundit`.

Second, I've come into the importing failure on some record validations, but I've got some ambiguous flash messages. So I updated `active_admin_import/dsl.rb` to yield failed messages, and made it shown on `config/locales/en.yml`.

![image](https://cloud.githubusercontent.com/assets/1019171/9257144/8f2f1e60-4226-11e5-8bdc-7838af12ceda.png)

Third, I'm a developer from China, so I added the `config/locales/zh-CN.yml` to make it work for other Chinese developers.

Fourth, I've added I18n support for custom import page view, PR the locale change and here is the custom view looks like (you may update it on the project page in Example9 on [http://fivell.github.io/active_admin_import/](http://fivell.github.io/active_admin_import/))

```ruby
<p>
  <%= raw(@active_admin_import_model.hint) %>
</p>
<%= semantic_form_for @active_admin_import_model, url: {action: :do_import}, html: {multipart: true} do |f| %>
  <%= f.inputs do %>
    <%= f.input :file, as: :file, label: t('active_admin_import.file') %>
  <% end %>
  <%= f.inputs t("active_admin_import.csv_options"), for: [:csv_options, OpenStruct.new(@active_admin_import_model.csv_options)] do |csv| %>
    <% csv.with_options input_html: {style: 'width:40px;'} do |opts| %>
      <%= opts.input :col_sep, label: t("active_admin_import.col_sep") %>
      <%= opts.input :row_sep, label: t("active_admin_import.row_sep") %>
      <%= opts.input :quote_char, label: t("active_admin_import.quote_char") %>
    <% end %>
  <% end %>

  <%= f.actions do %>
    <%= f.action :submit, label: t("active_admin_import.import_btn"), button_html: {disable_with: t("active_admin_import.import_btn_disabled")} %>
  <% end %>
<% end %>
```

Fifth, what's really confusing me is the importing procecess. Here is an example:

```ruby
# app/models/project.rb
class Project < ActiveRecord::Base
  validates_uniqueness_of :name
end
```

And I created 

```ruby
#<Project:0x007fc0da4c1e20> {
  :id          => 1,
  :name        => "name1",
  :description => "Hello World"
}
#<Project:0x007fc0da4c1e20> {
  :id          => 2,
  :name        => "name2,
  :description => "Hello World"
}
```

Now, when I import file

```
# projects.csv, files to import
name;description
name1;hello world
name2;hello world
name3;hello world
name4;hello world
name5;hello world
```

I've got notices that projects about `name3`, `name4`, `name5` were created, and `name1`, `name2` were violated the uniqnuess validation on `name`. Suppose I've got a large file to import, then everytime I need to remove the records which succeed importing and modify the violated record to make the importing work? I don't want my customer to identify the records which are valid and which are not. You may advise to use the `on_duplicate_key_update` option, but I'm using PostgreSQL which hasn't been supported by `activerecord-import`.

Here is my solution, I've found the transaction code in `lib/active_admin_import/importer.rb`

```ruby
def batch_import
  @resource.transaction do
    run_callback(:before_batch_import)
    batch_result = resource.import(headers.values, csv_lines, import_options)
    run_callback(:after_batch_import)
    batch_result
  end
end
```

The `import` method will never raise an exception in `activerecord_import` which triggers the transaction ROLLBACK. So I add a `:batch_transaction` option and update `batch_import` to:

```ruby
def batch_import
  batch_result = nil
  @resource.transaction do
    run_callback(:before_batch_import)
    batch_result = resource.import(headers.values, csv_lines, import_options)
    raise ActiveRecord::Rollback if import_options[:batch_transaction] && batch_result.failed_instances.any?
    run_callback(:after_batch_import)
  end
  batch_result
end
```

Now, when I import records which are valid and other are not, it will trigger a ROLLBACK until all importing records are valid. I think that's what the transaction mean.

Lastly, I've fixed some typos in README.

These are the thoughts I've run into, and hope this for discussion and help. 
