### PR TITLE
Feature/add batch transaction option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Tool                    | Description
 :csv_options			|hash with column separator, row separator, etc 
 :validate				|bool means perform validations or not
 :batch_size				|integer value of max  record count inserted by 1 query/transaction
+:batch_transaction    |bool (false by default), if transaction is used when batch importing and works when :validate is set to true
 :before_import			|proc for before import action, hook called with  importer object
 :after_import			|proc for after import action, hook called with  importer object
 :before_batch_import	|proc for before each batch action, called with  importer object

--- a/lib/active_admin_import/dsl.rb
+++ b/lib/active_admin_import/dsl.rb
@@ -8,6 +8,7 @@ module ActiveAdminImport
     # +back+:: resource action to redirect after processing
     # +csv_options+:: hash to override default CSV options
     # +batch_size+:: integer value of max  record count inserted by 1 query/transaction
+    # +batch_transaction+:: bool (false by default), if transaction is used when batch importing and works when :validate is set to true
     # +before_import+:: proc for before import action, hook called with  importer object
     # +after_import+:: proc for after import action, hook called with  importer object
     # +before_batch_import+:: proc for before each batch action, called with  importer object
@@ -31,11 +32,12 @@ module ActiveAdminImport
       if result.empty?
         flash[:warning] = I18n.t('active_admin_import.file_empty_error')
       else
-        if result.has_imported?
-          flash[:notice] = I18n.t('active_admin_import.imported', count: result.imported_qty, model: model_name, plural_model: plural_model_name)
-        end
         if result.has_failed?
           flash[:error] = I18n.t('active_admin_import.failed', count: result.failed.count, model: model_name, plural_model: plural_model_name)
+          return if options[:batch_transaction]
+        end
+        if result.has_imported?
+          flash[:notice] = I18n.t('active_admin_import.imported', count: result.imported_qty, model: model_name, plural_model: plural_model_name)
         end
       end
     end

--- a/lib/active_admin_import/options.rb
+++ b/lib/active_admin_import/options.rb
@@ -6,6 +6,7 @@ module ActiveAdminImport
         :csv_options,
         :validate,
         :batch_size,
+        :batch_transaction,
         :before_import,
         :after_import,
         :before_batch_import,

--- a/spec/fixtures/files/authors_invalid_model.csv
+++ b/spec/fixtures/files/authors_invalid_model.csv
@@ -1,0 +1,3 @@
+Name,Last name,Birthday
+Jim,Doe,1986-05-01
+Jane,Roe,1986-05-01

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -4,7 +4,7 @@ generate :model, 'author name:string{10}:uniq last_name:string birthday:date'
 generate :model, 'post title:string:uniq body:text author:references'
 
 #Add validation
-inject_into_file "app/models/author.rb", "  validates_presence_of :name\n", after: "Base\n"
+inject_into_file "app/models/author.rb", "  validates_presence_of :name\n  validates_uniqueness_of :last_name\n", after: "Base\n"
 inject_into_file "app/models/post.rb", "   validates_presence_of :author\n", after: ":author\n"
 
 # Configure default_url_options in test environment


### PR DESCRIPTION
This is the core part when importing from csv.

```ruby
def batch_import
  @resource.transaction do
    run_callback(:before_batch_import)
    batch_result = resource.import(headers.values, csv_lines, import_options)
    run_callback(:after_batch_import)
    batch_result
  end
end
```

What confusing me is that the transaction won't rollback, when some records fail on validation. It means that now the csv file is partially imported, and I need to modify the failed records and delete the succeed records to import again, which seems weird to me.

The transaction relies on the `import` method defined by *activerecord-import*. The `import` method does the validation and saves the result to `failed_instances`, which will never raise an exception on validation. Check the code for details https://github.com/zdennis/activerecord-import/blob/6c06b3ceb53f83e1ce930eab35cdd4b6375c57ca/lib/activerecord-import/import.rb#L340-L365

So I made this update to manually trigger a rollback:

```ruby
raise ActiveRecord::Rollback if import_options[:batch_transaction] &&
batch_result.failed_instances.any?
```

P.S.

The validation I'm talking about is on model level, not on DB
level. The `import` method will raise the DB level exception to tirgger
the rollback, like add a record with a duiplicate field which has a uniq index.

- - -

Add `validates_uniqueness_of :last_name` to *Author* model, because the
original `validates_presence_of :name` barely works.

```ruby
context "with invalid data insert" do
  it "should render error" do
    upload_file!(:authors_invalid_db)
    expect(page).to have_content "Error:"
    expect(Author.count).to eq(0)
  end
end
```

The spec above catches an `Error: SQLite
3::ConstraintException: column name is not unique`, the really
constraint is on DB level.

```ruby
add_index "authors", ["name"], name: "index_authors_on_name", unique:
true
````

The option `:batch_transaction` controls the transaction on
model level, so I've add an rspec context "with invalid data insert on model
validation".