### PR TITLE
fix Rails5 related issues

### DIFF
--- a/active_admin_import.gemspec
+++ b/active_admin_import.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version = ActiveAdminImport::VERSION
 
 
-  gem.add_runtime_dependency 'activerecord-import', '~> 0.10.0'
+  gem.add_runtime_dependency 'activerecord-import', '~> 0.12.0'
   gem.add_runtime_dependency 'rchardet', '~> 1.6'
 
   gem.add_runtime_dependency 'rubyzip', '~> 1.1', '>= 1.0.0'

--- a/lib/active_admin_import/dsl.rb
+++ b/lib/active_admin_import/dsl.rb
@@ -65,7 +65,7 @@ module ActiveAdminImport
         authorize!(ActiveAdminImport::Auth::IMPORT, active_admin_config.resource_class)
 
         @active_admin_import_model = options[:template_object]
-        @active_admin_import_model.assign_attributes(params[params_key].try(:deep_symbolize_keys) || {})
+        @active_admin_import_model.assign_attributes(params[params_key].to_unsafe_h.deep_symbolize_keys) if params[params_key]
         #go back to form
         return render template: options[:template] unless @active_admin_import_model.valid?
         @importer = Importer.new(options[:resource_class], @active_admin_import_model, options)


### PR DESCRIPTION
Fixes for #91. Take a look, I think it's back compatible prior to 4.2 version. (version 4.1 has no `to_unsafe_h` method on ActionController::Parameters instance)

* "no file to import" issue fixed
* "no method error" on type_cast method fixed