### PR TITLE
Add pt-BR translation files

### DIFF
--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,0 +1,23 @@
+pt-BR:
+  active_admin:
+    import: "Importar"
+  active_admin_import:
+    file: 'Arquivo'
+    file_error: "Error: %{message}"
+    file_format_error: "Você só pode importar arquivos csv válidos"
+    file_empty_error: "Você não pode importar arquivos vázios"
+    no_file_error: "Por favor, selecione o arquivo para importar"
+    details: "Por favor, selecione o arquivo para importar"
+    imported:
+      one: "Importado com sucesso 1 %{model}"
+      other: "Importado com sucesso %{count} %{plural_model}"
+    failed:
+      one:   "Não foi possível importar 1 %{model}: %{message}"
+      other: "Não foi possível importar %{count} %{plural_model}: %{message}"
+    import_model: "Importar %{plural_model}"
+    import_btn: "Importr"
+    import_btn_disabled: "Aguarde..."
+    csv_options: "opções CSV"
+    col_sep: 'Col sep'
+    row_sep: 'Row sep'
+    quote_char: 'Quote char'


### PR DESCRIPTION
This commit adds the brazillian portuguese translation files.

Note that I didn't translate the lasts keys (col_sel, row_sep,
quote_chore), because I consider them technical terms, and I'm not sure
what a good name for them in portuguese would be, I rather instigate the
users curiosity, and have them google the term.