### PR TITLE
We need to call record.valid?

### DIFF
--- a/lib/active_admin_import/import_result.rb
+++ b/lib/active_admin_import/import_result.rb
@@ -32,6 +32,7 @@ module ActiveAdminImport
     def failed_message(options = {})
       limit = options.fetch(:limit, failed.count)
       failed.first(limit).map do |record|
+        record.valid?
         errors = record.errors
         (errors.full_messages.zip errors.keys.map { |k| record.send k }).map { |ms| ms.join(' - ') }.join(', ')
       end.join(' ; ')

--- a/lib/active_admin_import/import_result.rb
+++ b/lib/active_admin_import/import_result.rb
@@ -32,7 +32,6 @@ module ActiveAdminImport
     def failed_message(options = {})
       limit = options.fetch(:limit, failed.count)
       failed.first(limit).map do |record|
-        record.valid?
         errors = record.errors
         (errors.full_messages.zip errors.keys.map { |k| record.send k }).map { |ms| ms.join(' - ') }.join(', ')
       end.join(' ; ')

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -311,6 +311,7 @@ describe 'import', type: :feature do
         it 'should render both successful and failed message' do
           upload_file!(:authors_invalid_model)
           expect(page).to have_content 'Failed to import 1 author'
+          expect(page).to have_content 'Last name has already been taken - Doe'
           expect(page).to have_content 'Successfully imported 1 author'
           expect(Author.count).to eq(2)
         end
@@ -320,7 +321,8 @@ describe 'import', type: :feature do
 
           it 'should render only the failed message' do
             upload_file!(:authors_invalid_model)
-            expect(page).to     have_content 'Failed to import 1 author'
+            expect(page).to have_content 'Failed to import 1 author'
+            expect(page).to have_content 'Last name has already been taken - Doe'
             expect(page).to_not have_content 'Successfully imported'
             expect(Author.count).to eq(1)
           end


### PR DESCRIPTION
To populate `record.errors` we must first call `.valid?`