### PR TITLE
Parent resource is made accesible through the template object when th…

### DIFF
--- a/lib/active_admin_import/dsl.rb
+++ b/lib/active_admin_import/dsl.rb
@@ -77,6 +77,8 @@ module ActiveAdminImport
         params = ActiveSupport::HashWithIndifferentAccess.new _params
         @active_admin_import_model = options[:template_object]
         @active_admin_import_model.assign_attributes(params[params_key].try(:deep_symbolize_keys) || {})
+        @active_admin_import_model.assign_attributes(parent: parent) if respond_to?(:parent)
+
         # go back to form
         return render template: options[:template] unless @active_admin_import_model.valid?
         @importer = Importer.new(


### PR DESCRIPTION
…e active admin page has the 'belongs_to' statement.

I needed to implement this change in order to get a reference of the parent resource within a proc passed to the before_batch_import option in order to insert additional information to each line. 
 
```
  before_batch_import: Proc.new{|importer|         
       _form = importer.model.parent
        importer.csv_lines.each do |line|
          line.push _form.id
          line.push _form.generate_registration_code
        end
  }
```

I was not sure where and how to document this change.

What do you think about this proposal?