### PR TITLE
Add ability to cover import in transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Tool                    | Description
 :after_import           |proc for after import action, hook called with  importer object
 :before_batch_import    |proc for before each batch action, called with  importer object
 :after_batch_import     |proc for after each batch action, called with  importer object
+:transaction_callbacks  |bool, tells activerecord-import to run you before_import and after_import in a transaction
 :on_duplicate_key_update|an Array or Hash, tells activerecord-import to use MySQL's ON DUPLICATE KEY UPDATE or Postgres 9.5+ ON CONFLICT DO UPDATE ability.
 :timestamps             |bool, tells activerecord-import to not add timestamps (if false) even if record timestamps is disabled in ActiveRecord::Base
 :ignore                 |bool, tells activerecord-import to use MySQL's INSERT IGNORE ability

--- a/lib/active_admin_import/dsl.rb
+++ b/lib/active_admin_import/dsl.rb
@@ -12,6 +12,7 @@ module ActiveAdminImport
   # +after_import+:: proc for after import action, hook called with  importer object
   # +before_batch_import+:: proc for before each batch action, called with  importer object
   # +after_batch_import+:: proc for after each batch action, called with  importer object
+  # +transaction_callbacks+:: true|false, tells activerecord-import to run you before_import and after_import in a transaction
   # +validate+:: true|false, means perform validations or not
   # +on_duplicate_key_update+:: an Array or Hash, tells activerecord-import
   # to use MySQL's ON DUPLICATE KEY UPDATE ability.
@@ -85,7 +86,7 @@ module ActiveAdminImport
           options
         )
         begin
-          result = @importer.import
+          result = options[:transaction_callbacks] ? @importer.transaction_import : @importer.import
 
           if block_given?
             instance_eval(&block)

--- a/lib/active_admin_import/importer.rb
+++ b/lib/active_admin_import/importer.rb
@@ -47,6 +47,12 @@ module ActiveAdminImport
       import_result
     end
 
+    def transaction_import
+      @resource.transaction do
+        import
+      end
+    end
+
     def import_options
       @import_options ||= options.slice(:validate, :on_duplicate_key_update, :ignore, :timestamps, :batch_transaction)
     end

--- a/lib/active_admin_import/options.rb
+++ b/lib/active_admin_import/options.rb
@@ -11,6 +11,7 @@ module ActiveAdminImport
       :after_import,
       :before_batch_import,
       :after_batch_import,
+      :transaction_callbacks,
       :on_duplicate_key_update,
       :timestamps,
       :ignore,

--- a/lib/active_admin_import/version.rb
+++ b/lib/active_admin_import/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ActiveAdminImport
-  VERSION = '3.0.0'
+  VERSION = '3.0.1'
 end


### PR DESCRIPTION
### Problem
I want to make replacement with import. Though, if any error is happened during import user is left with empty table. 

### Solution
Add option to run before and after callbacks in transactions. Default behavior remains same (no transactions) but for cases like mine (when you want to do something in before)callbacks only on success) it would solve the problem

Thanks for your work on this gem!