### PR TITLE
Add possibility to skip columns/values in CSV

### DIFF
--- a/lib/active_admin_import/importer.rb
+++ b/lib/active_admin_import/importer.rb
@@ -60,6 +60,30 @@ module ActiveAdminImport
       end
     end
 
+    # Use it when CSV file contain redundant columns
+    #
+    # Example:
+    #
+    # ActiveAdmin.register Post
+    #   active_admin_import before_batch_import: lambda { |importer|
+    #                         importer.batch_slice_columns(['name', 'birthday'])
+    #                       }
+    # end
+    #
+    def batch_slice_columns(slice_columns)
+      use_indexes = []
+      headers.values.each_with_index do |val, index|
+        use_indexes << index if val.in?(slice_columns)
+      end
+      return csv_lines if use_indexes.empty?
+      # slice CSV headers
+      @headers = headers.to_a.values_at(*use_indexes).to_h
+      # slice CSV values
+      csv_lines.map! do |line|
+        line.values_at(*use_indexes)
+      end
+    end
+
     def values_at(header_key)
       csv_lines.collect { |line| line[header_index(header_key)] }.uniq
     end


### PR DESCRIPTION
Add function `batch_slice_columns` which meant to resolve issue
when CSV contains some redundant columns,
or columns not existing in corresponding Model

Usage example:

```ruby
ActiveAdmin.register Post
  active_admin_import before_batch_import: lambda { |importer|
                        importer.batch_slice_columns(['name', 'birthday'])
                      }
end
```

In this example  Post has columns 'name', 'last_name' and 'birthday'
And on import only 'name' and 'birthday' will be used in INSERT-SQL

 Changes to be committed: