### PR TITLE
bump 3.1.0 and lower activeadmin to 1.0.0.pre2

### DIFF
--- a/active_admin_import.gemspec
+++ b/active_admin_import.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'activerecord-import', '~> 0.17.0'
   gem.add_runtime_dependency 'rchardet', '~> 1.6'
   gem.add_runtime_dependency 'rubyzip', '~> 1.2'
-  gem.add_dependency 'activeadmin', '~> 1.0'
+  gem.add_dependency 'activeadmin', '>= 1.0.0.pre2'
 end

--- a/lib/active_admin_import/version.rb
+++ b/lib/active_admin_import/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ActiveAdminImport
-  VERSION = '3.0.0'
+  VERSION = "3.1.0"
 end


### PR DESCRIPTION
downgrade dependency of ActiveAdmin to `>= 1.0.0.pre2`