### PR TITLE
Update activerecord-import version requirement

### DIFF
--- a/active_admin_import.gemspec
+++ b/active_admin_import.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.name = 'active_admin_import'
   gem.require_paths = ['lib']
   gem.version = ActiveAdminImport::VERSION
-  gem.add_runtime_dependency 'activerecord-import', '~> 0.17.0'
+  gem.add_runtime_dependency 'activerecord-import', '>= 0.17.0'
   gem.add_runtime_dependency 'rchardet', '~> 1.6'
   gem.add_runtime_dependency 'rubyzip', '~> 1.2'
   gem.add_dependency 'activeadmin', '>= 1.0.0.pre2'


### PR DESCRIPTION
Resolves https://github.com/activeadmin-plugins/active_admin_import/issues/151

This originally changed from `>= 0.16.1` to `~> 0.17.0` in https://github.com/activeadmin-plugins/active_admin_import/commit/ad624c284b7acfaa4a2a0e7657b86ad7dc835c34 although it's not clear why from the release notes.