### PR TITLE
Drop Rails 4 support in development environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## [Unreleased]
+
+## [4.0.0] - 2018-07-19
+- Adde German translation | @morris-frank
+- Remove support for Ruby 2.1 and Rails 4
+
+## [3.1.0] - 2018-04-10
+- Lower dependency of ActiveAdmin to >= 1.0.0.pre2
+- Add possibility to skip columns/values in CSV (batch_slice_columns method)
+
+[Unreleased]: https://github.com/activeadmin-plugins/active_admin_import/compare/v4.0.0...HEAD
+[4.0.0]: https://github.com/activeadmin-plugins/active_admin_import/compare/v3.1.0...v4.0.0
+[3.1.0]: https://github.com/activeadmin-plugins/active_admin_import/compare/3.0.0...v3.1.0

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 
 
 group :test do
-  default_rails_version = '4.2.8'
+  default_rails_version = "~> 5.1"
   rails_version = ENV['RAILS'] || default_rails_version
   gem 'rails', rails_version
   gem 'rspec-rails'

--- a/lib/active_admin_import/version.rb
+++ b/lib/active_admin_import/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ActiveAdminImport
-  VERSION = "3.1.0"
+  VERSION = "4.0.0"
 end


### PR DESCRIPTION
- Drop Rails 4 from Gemfile, use 5-version instead
- Add CHANGELOG.md #140
- Bump gem version to 4.0.0

Recent change in #155 actually means a "breaking changes". That's why I propose to change major number version. Or it is over exaggerated? :rotating_light: