### PR TITLE
Update activerecord-import dependency

### DIFF
--- a/active_admin_import.gemspec
+++ b/active_admin_import.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.name = 'active_admin_import'
   gem.require_paths = ['lib']
   gem.version = ActiveAdminImport::VERSION
-  gem.add_runtime_dependency 'activerecord-import', '~> 0.17.0'
+  gem.add_runtime_dependency 'activerecord-import', '~> 0.25.0'
   gem.add_runtime_dependency 'rchardet', '~> 1.6'
   gem.add_runtime_dependency 'rubyzip', '~> 1.2'
   gem.add_dependency 'activeadmin', '>= 1.0.0.pre2'


### PR DESCRIPTION
Latest version of activerecord-import 0.25.0 in dependencies.