### PR TITLE
Upgrade to activerecord-import 0.27.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,17 @@ Tool                    | Description
 ---------------------   | -----------
 :back                   |resource action to redirect after processing
 :csv_options            |hash with column separator, row separator, etc
-:validate               |bool means perform validations or not
+:validate               |bool (true by default), perform validations or not
+:batch_transaction      |bool (false by default), if transaction is used when batch importing and works when :validate is set to true
 :batch_size             |integer value of max  record count inserted by 1 query/transaction
-:batch_transaction    |bool (false by default), if transaction is used when batch importing and works when :validate is set to true
 :before_import          |proc for before import action, hook called with  importer object
 :after_import           |proc for after import action, hook called with  importer object
 :before_batch_import    |proc for before each batch action, called with  importer object
 :after_batch_import     |proc for after each batch action, called with  importer object
-:on_duplicate_key_update|an Array or Hash, tells activerecord-import to use MySQL's ON DUPLICATE KEY UPDATE or Postgres 9.5+ ON CONFLICT DO UPDATE ability.
+:on_duplicate_key_update|an Array or Hash, tells activerecord-import to use MySQL's ON DUPLICATE KEY UPDATE or Postgres 9.5+/SQLite 3.24.0+ ON CONFLICT DO UPDATE ability
+:on_duplicate_key_ignore|bool, tells activerecord-import to use MySQL's INSERT IGNORE or Postgres 9.5+ ON CONFLICT DO NOTHING or SQLite's INSERT OR IGNORE ability
+:ignore                 |bool, alias for on_duplicate_key_ignore
 :timestamps             |bool, tells activerecord-import to not add timestamps (if false) even if record timestamps is disabled in ActiveRecord::Base
-:ignore                 |bool, tells activerecord-import to use MySQL's INSERT IGNORE ability
 :template               |custom template rendering
 :template_object        |object passing to view
 :resource_class         |resource class name

--- a/active_admin_import.gemspec
+++ b/active_admin_import.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.name = 'active_admin_import'
   gem.require_paths = ['lib']
   gem.version = ActiveAdminImport::VERSION
-  gem.add_runtime_dependency 'activerecord-import', '~> 0.17.0'
+  gem.add_runtime_dependency 'activerecord-import', '>= 0.27.0'
   gem.add_runtime_dependency 'rchardet', '~> 1.6'
   gem.add_runtime_dependency 'rubyzip', '~> 1.2'
   gem.add_dependency 'activeadmin', '>= 1.0.0.pre2'

--- a/lib/active_admin_import/importer.rb
+++ b/lib/active_admin_import/importer.rb
@@ -8,6 +8,7 @@ module ActiveAdminImport
     OPTIONS = [
       :validate,
       :on_duplicate_key_update,
+      :on_duplicate_key_ignore,
       :ignore,
       :timestamps,
       :before_import,
@@ -48,7 +49,16 @@ module ActiveAdminImport
     end
 
     def import_options
-      @import_options ||= options.slice(:validate, :on_duplicate_key_update, :ignore, :timestamps, :batch_transaction)
+      @import_options ||= options.slice(
+        :validate,
+        :validate_uniqueness,
+        :on_duplicate_key_update,
+        :on_duplicate_key_ignore,
+        :ignore,
+        :timestamps,
+        :batch_transaction,
+        :batch_size
+      )
     end
 
     def batch_replace(header_key, options)
@@ -134,7 +144,10 @@ module ActiveAdminImport
     end
 
     def assign_options(options)
-      @options = { batch_size: 1000, validate: true }.merge(options.slice(*OPTIONS))
+      @options = {
+        batch_size: 1000,
+        validate_uniqueness: true
+      }.merge(options.slice(*OPTIONS))
       detect_csv_options
     end
 


### PR DESCRIPTION
An option to enable uniqueness validators was added to activerecord-import v0.27.0. There are several pitfalls with attempting uniqueness validation, so it is still not recommended. See https://github.com/zdennis/activerecord-import/issues/228 for more info.

Closes #151, #152, #160.