### PR TITLE
Fix activerecord-import link

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,7 +340,7 @@ with support of validations, bulk inserts and encodings handling</p>
 <td>Character encoding auto-detection in Ruby. As smart as your browser. Open source.</td>
 </tr>
 <tr>
-<td><a href="https://github.com/jmhodges/rchardet">activerecord-import</a></td>
+<td><a href="https://github.com/zdennis/activerecord-import">activerecord-import</a></td>
 <td>Powerful library for bulk inserting data using ActiveRecord.</td>
 </tr>
 </tbody>


### PR DESCRIPTION
The link was wrong so I fixed it.