### PR TITLE
Allow batch_slice_columns to work when batching

### DIFF
--- a/lib/active_admin_import/importer.rb
+++ b/lib/active_admin_import/importer.rb
@@ -70,7 +70,7 @@ module ActiveAdminImport
       end
     end
 
-    # Use it when CSV file contain redundant columns
+    # Use this method when CSV file contains unnecessary columns
     #
     # Example:
     #
@@ -81,16 +81,22 @@ module ActiveAdminImport
     # end
     #
     def batch_slice_columns(slice_columns)
-      use_indexes = []
-      headers.values.each_with_index do |val, index|
-        use_indexes << index if val.in?(slice_columns)
+      # Only set @use_indexes for the first batch so that @use_indexes are in correct
+      # position for subsequent batches
+      unless defined?(@use_indexes)
+        @use_indexes = []
+        headers.values.each_with_index do |val, index|
+          @use_indexes << index if val.in?(slice_columns)
+        end
+        return csv_lines if @use_indexes.empty?
+
+        # slice CSV headers
+        @headers = headers.to_a.values_at(*@use_indexes).to_h
       end
-      return csv_lines if use_indexes.empty?
-      # slice CSV headers
-      @headers = headers.to_a.values_at(*use_indexes).to_h
+
       # slice CSV values
       csv_lines.map! do |line|
-        line.values_at(*use_indexes)
+        line.values_at(*@use_indexes)
       end
     end
 

--- a/spec/fixtures/files/authors.csv
+++ b/spec/fixtures/files/authors.csv
@@ -1,3 +1,3 @@
-Name,Last name,Birthday
-John,Doe,1986-05-01
-Jane,Roe,1988-11-16
+Birthday,Name,Last name
+1986-05-01,John,Doe
+1988-11-16,Jane,Roe


### PR DESCRIPTION
Currently the `use_indexes` are set correctly only for the first batch.

You may be wondering why I re-ordered the columns in authors.csv. I did this because it was the best way I could find to get a good failing test for my use case. I could not test removing the `name` because that column is required. I couldn't test removing the `last_name` column because that column needs to be unique and validation would fail for the second batch because the first batch (and record) would have a `NULL` value for `last_name`. I also could not use the `date` column in its former order because the bug only manifests when columns other than the last one(s) are sliced.