### PR TITLE
Allow activerecord-import >= 0.27

### DIFF
--- a/active_admin_import.gemspec
+++ b/active_admin_import.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.name = 'active_admin_import'
   gem.require_paths = ['lib']
   gem.version = ActiveAdminImport::VERSION
-  gem.add_runtime_dependency 'activerecord-import', '~> 0.27'
+  gem.add_runtime_dependency 'activerecord-import', '>= 0.27'
   gem.add_runtime_dependency 'rchardet', '~> 1.6'
   gem.add_runtime_dependency 'rubyzip', '~> 1.2'
   gem.add_dependency 'activeadmin', '>= 1.0.0.pre2'


### PR DESCRIPTION
This fork repo is made so that we can use this Active Admin import gem but without the activerecord-import version restriction.

We are actually using activerecord-import > 1.0.0 in our project but in their project they decided that the dependency of activerecord-import gem must be a fixed older version (2018).

The reason for this fixed dependency was some kind of corner cases with uniqueness validations failing on certain occasions.
