### PR TITLE
Support for a non UTF-8 file when zip uploading

### DIFF
--- a/lib/active_admin_import/model.rb
+++ b/lib/active_admin_import/model.rb
@@ -110,7 +110,7 @@ module ActiveAdminImport
 
     def unzip_file
       Zip::File.open(file_path) do |zip_file|
-        self.file = Tempfile.new(CONST::TMP_FILE)
+        self.file = Tempfile.new(CONST::TMP_FILE, binmode: true)
         data = zip_file.entries.select(&:file?).first.get_input_stream.read
         file << data
         file.close

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -371,6 +371,20 @@ describe 'import', type: :feature do
             end
           end
         end
+
+        context 'when zipped with Win1251 file' do
+          let(:options) do
+            attributes = { force_encoding: :auto }
+            { template_object: ActiveAdminImport::Model.new(attributes) }
+          end
+          it 'should import file' do
+            with_zipped_csv(:authors_win1251_win_endline) do
+              upload_file!(:authors_win1251_win_endline, :zip)
+              expect(page).to have_content 'Successfully imported 2 authors'
+              expect(Author.count).to eq(2)
+            end
+          end
+        end
       end
 
       context 'with different header attribute names' do


### PR DESCRIPTION
I work on a Japanese project.
Occurred Encoding::UndefinedConversionError for non utf-8 file when zip uploading, so I made this.