### PR TITLE
Add compatibility for Ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ jobs:
     - rvm: 2.4.10
       env: RAILS=6.0.3.7
     - rvm: 3.0.1
-      env: RAILS=6.0.3.7
+      env: RAILS=5.2.4.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,17 @@
 script: bundle exec rspec spec
 env:
   matrix:
-    - RAILS=5.2.4.3
-    - RAILS=6.0.3.2
+    - RAILS=5.2.4.6
+    - RAILS=6.0.3.7
 rvm:
-  - 2.4.5
-  - 2.5.5
-  - 2.6.5
-  - 2.7.0
-  - 2.7.1
+  - 2.4.10
+  - 2.5.9
+  - 2.6.7
+  - 2.7.3
+  - 3.0.1
 jobs:
   exclude:
-    - rvm: 2.4.5
-      env: RAILS=6.0.3.2
+    - rvm: 2.4.10
+      env: RAILS=6.0.3.7
+    - rvm: 3.0.1
+      env: RAILS=6.0.3.7

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 group :test do
   default_rails_version = "~> 5.2.4"
   rails_version = ENV['RAILS'] || default_rails_version
+  gem 'sassc-rails'
   gem 'rails', rails_version
   gem 'rspec-rails'
   gem 'coveralls', require: false # Test coverage website. Go to https://coveralls.io

--- a/lib/active_admin_import/importer.rb
+++ b/lib/active_admin_import/importer.rb
@@ -37,7 +37,7 @@ module ActiveAdminImport
     end
 
     def cycle(lines)
-      @csv_lines = CSV.parse(lines.join, @csv_options)
+      @csv_lines = CSV.parse(lines.join, **@csv_options)
       import_result.add(batch_import, lines.count)
     end
 
@@ -115,7 +115,7 @@ module ActiveAdminImport
       batch_size = options[:batch_size].to_i
       File.open(file.path) do |f|
         # capture headers if not exist
-        prepare_headers { CSV.parse(f.readline, @csv_options).first }
+        prepare_headers { CSV.parse(f.readline, **@csv_options).first }
         f.each_line do |line|
           lines << line if line.present?
           if lines.size == batch_size || f.eof?


### PR DESCRIPTION
This addresses two issues where method calls needed to be updated due to changes in [Ruby 3.0 argument passing](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/). I also updated the CI configuration to add Ruby 3 and newer bugfix builds of Ruby/Rails, but happy to revert those changes if needed. I also added sassc-rails to the Gemfile, as development/testing doesn't work out of the box without it.

Fixes https://github.com/activeadmin-plugins/active_admin_import/issues/189