### PR TITLE
Store result ids on ImportResult (postgres only)

### DIFF
--- a/lib/active_admin_import/import_result.rb
+++ b/lib/active_admin_import/import_result.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 module ActiveAdminImport
   class ImportResult
-    attr_reader :failed, :total
+    attr_reader :failed, :ids, :total
 
     def initialize
       @failed = []
+      @ids = []
       @total = 0
     end
 
     def add(result, qty)
       @failed += result.failed_instances
-      @total  += qty
+      @ids += result.ids
+      @total += qty
     end
 
     def imported_qty

--- a/spec/import_result_spec.rb
+++ b/spec/import_result_spec.rb
@@ -14,13 +14,21 @@ describe ActiveAdminImport::ImportResult do
      ]
     end
 
+    let(:ids){ [1,2] }
+
     before do
       @result = double \
-        failed_instances: failed_instances
+        failed_instances: failed_instances,
+        ids: ids
     end
 
     it 'should work without any failed instances' do
       expect(import_result.failed_message).to eq('')
+    end
+
+    it 'should store the supplied ids' do
+      import_result.add(@result, 4)
+      expect(import_result.ids).to eq(ids)
     end
 
     it 'should work' do


### PR DESCRIPTION
I was looking for a solution to https://github.com/activeadmin-plugins/active_admin_import/issues/179

Luckily I'm using postgres, and activerecord-import stores the ids for postgres: https://github.com/zdennis/activerecord-import#return-info

I understand this is not the ideal solution for everyone, but it's consistent with the behavior of the underlying base library.

Let me know if this is something you would like to add or if you need any other changes.