### PR TITLE
Ensure rails6.2 and later error message 

### DIFF
--- a/lib/active_admin_import/import_result.rb
+++ b/lib/active_admin_import/import_result.rb
@@ -35,13 +35,12 @@ module ActiveAdminImport
         errors = record.errors
         # Avoid an error when ActiveModel::Errors#keys is deprecated.
         if Gem::Version.new(Rails.version) >= Gem::Version.new('6.2')
-          failed_values = errors.attribute_names.map do |key|
-            key == :base ? nil : record.public_send(key)
-          end
+          attribute_names = errors.attribute_names
         else
-          failed_values = errors.keys.map do |key|
-            key == :base ? nil : record.public_send(key)
-          end
+          attribute_names = errors.keys
+        end
+        failed_values = attribute_names.map do |key|
+          key == :base ? nil : record.public_send(key)
         end
         errors.full_messages.zip(failed_values).map { |ms| ms.compact.join(' - ') }.join(', ')
       end.join(' ; ')

--- a/lib/active_admin_import/import_result.rb
+++ b/lib/active_admin_import/import_result.rb
@@ -33,8 +33,15 @@ module ActiveAdminImport
       limit = options[:limit] || failed.count
       failed.first(limit).map do |record|
         errors = record.errors
-        failed_values = errors.keys.map do |key|
-          key == :base ? nil : record.public_send(key)
+        # Avoid an error when ActiveModel::Errors#keys is deprecated.
+        if Gem::Version.new(Rails.version) >= Gem::Version.new('6.2')
+          failed_values = errors.attribute_names.map do |key|
+            key == :base ? nil : record.public_send(key)
+          end
+        else
+          failed_values = errors.keys.map do |key|
+            key == :base ? nil : record.public_send(key)
+          end
         end
         errors.full_messages.zip(failed_values).map { |ms| ms.compact.join(' - ') }.join(', ')
       end.join(' ; ')


### PR DESCRIPTION
Hi team,

I've added support to display error messages for Rails 6.2 and later in this PR. That changes include coverage earlier than 6.0 versions. Please review and merge this PR into the main branch.

Thanks!

```
rbenv local 2.4.1
bundle install  
bundle exec rake setup 
cd spec/rails/rails-5.2.8.1
bundle exec rake db:create
RAILS_ENV=test bundle exec rake db:migrate
cd -
bundle exec rspec

Finished in 4.54 seconds (files took 2.45 seconds to load)
49 examples, 0 failures
```
