### PR TITLE
Fix errors with invalid csv

### DIFF
--- a/lib/active_admin_import/dsl.rb
+++ b/lib/active_admin_import/dsl.rb
@@ -94,6 +94,7 @@ module ActiveAdminImport
           end
         rescue ActiveRecord::Import::MissingColumnError,
                NoMethodError,
+               ArgumentError,
                ActiveRecord::StatementInvalid,
                CSV::MalformedCSVError,
                ActiveAdminImport::Exception => e

--- a/lib/active_admin_import/model.rb
+++ b/lib/active_admin_import/model.rb
@@ -103,6 +103,8 @@ module ActiveAdminImport
 
     def encode_file
       data = File.read(file_path)
+      return if data.empty?
+
       File.open(file_path, 'w') do |f|
         f.write(encode(data))
       end

--- a/spec/fixtures/files/authors_values_exceeded_headers.csv
+++ b/spec/fixtures/files/authors_values_exceeded_headers.csv
@@ -1,0 +1,3 @@
+Birthday,Name,Last name
+1986-05-01,John,Doe
+1988-11-16,Jane,Roe, exceeded value

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -440,6 +440,20 @@ describe 'import', type: :feature do
           expect(Author.count).to eq(0)
         end
       end
+
+      context 'with csv which has exceeded values' do
+        before do
+          upload_file!(:authors_values_exceeded_headers)
+        end
+
+        it 'should render warning' do
+          # 5 columns: 'birthday, name, last_name, created_at, updated_at'
+          # 6 values: '"1988-11-16", "Jane", "Roe", " exceeded value", datetime, datetime'
+          msg = 'Number of values (6) exceeds number of columns (5)'
+          expect(page).to have_content I18n.t('active_admin_import.file_error', message: msg)
+          expect(Author.count).to eq(0)
+        end
+      end
     end
 
     context 'with callback procs options' do

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -424,6 +424,22 @@ describe 'import', type: :feature do
           expect(Author.count).to eq(2)
         end
       end
+
+      context 'with empty csv and auto detect encoding' do
+        let(:options) do
+          attributes = { force_encoding: :auto }
+          { template_object: ActiveAdminImport::Model.new(attributes) }
+        end
+
+        before do
+          upload_file!(:empty)
+        end
+
+        it 'should render warning' do
+          expect(page).to have_content I18n.t('active_admin_import.file_empty_error')
+          expect(Author.count).to eq(0)
+        end
+      end
     end
 
     context 'with callback procs options' do


### PR DESCRIPTION
We have 2 situation when raised errors without handling:

1. Empty CSV and model has force_encoding: 'auto'
In this case encoding detected automatically by
```ruby
    def dynamic_encoding(data)
      CharDet.detect(data)['encoding']
    end
```
But if data is empty string '' result will be nil. `data.force_encoding(encoding_name)` where `data is empty string and encoding_name is nil` raise TypeError: no implicit conversion of nil into String

2. When we have invalid csv in which values exceeded headers activerecord_import gem raised ArgumentError:
```ruby
 raise ArgumentError, "Number of values (#{arr.length}) exceeds number of columns (#{columns.length})"
```
We can handle it in collection_action and return flash message to users