### PR TITLE
Fix bugs with caching and format validation when importing files

### DIFF
--- a/lib/active_admin_import/model.rb
+++ b/lib/active_admin_import/model.rb
@@ -37,7 +37,7 @@ module ActiveAdminImport
     validate :file_contents_present, if: ->(me) { me.file.present? }
 
     before_validation :unzip_file, if: ->(me) { me.archive? && me.allow_archive? }
-    before_validation :encode_file, if: ->(me) { me.force_encoding? && me.file.present? }
+    after_validation :encode_file, if: ->(me) { me.errors.empty? && me.force_encoding? && me.file.present? }
 
     attr_reader :attributes
 

--- a/spec/fixtures/files/author_invalid_format.txt
+++ b/spec/fixtures/files/author_invalid_format.txt
@@ -1,0 +1,2 @@
+Name,Last name,Birthday
+John,Doe,1986-05-01

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -610,4 +610,20 @@ describe 'import', type: :feature do
       end.not_to change { Author.count }
     end
   end
+
+  context 'when importing file with invalid format and auto force_encoding' do
+    let(:options) { { template_object: ActiveAdminImport::Model.new(force_encoding: :auto) } }
+
+    before do
+      add_author_resource(options)
+      visit '/admin/authors/import'
+    end
+
+    it 'should reject invalid file format before encoding' do
+      expect do
+        upload_file!(:author_invalid_format, 'txt')
+        expect(page).to have_content I18n.t('active_admin_import.file_format_error')
+      end.not_to change { Author.count }
+    end
+  end
 end


### PR DESCRIPTION
## [Bug 1: File caching issue - form reuses cached file after validation error](https://github.com/activeadmin-plugins/active_admin_import/issues/205#issue-3871768217)

#### Short Description
When submitting the import form after a validation error, the system reuses the previously cached file instead of showing the "no file" error when no file is selected. This causes confusion and potential unintended data imports.

For more details, see #205

---


## [Bug 2: File format validation occurs after encoding when using auto force_encoding](https://github.com/activeadmin-plugins/active_admin_import/issues/206#issue-3871776328)
#### Short Description
When `force_encoding: :auto` is configured, the file encoding process runs BEFORE file format validation. This causes the system to attempt encoding operations on invalid file formats (e.g., `.txt` files), leading to unnecessary processing overhead and incorrect error handling flow.

For more details, see #206 


--- 

### Local tests result
```
bundle exec rspec spec/import_spec.rb  
```
<img width="539" height="116" alt="Screenshot 2026-01-29 at 19 11 21" src="https://github.com/user-attachments/assets/57b622ab-66fc-4e7a-9163-7a1f8ac69661" />
