### PR TITLE
Add Rails 8.0.0 to CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['3.2', '3.3', '3.4']
-        rails: ['7.1.0', '7.2.0']
+        rails: ['7.1.0', '7.2.0', '8.0.0']
         activeadmin: ['3.2.0', '3.3.0', '3.4.0', '3.5.1']
+        exclude:
+          - rails: '8.0.0'
+            activeadmin: '3.2.0'
     env:
       RAILS: ${{ matrix.rails }}
       AA: ${{ matrix.activeadmin }}

--- a/Gemfile
+++ b/Gemfile
@@ -4,16 +4,10 @@ gemspec
 default_rails_version = '7.1.0'
 default_activeadmin_version = '3.2.0'
 
-rails_version = ENV['RAILS'] || default_rails_version
-gem 'rails', "~> #{rails_version}"
+gem 'rails', "~> #{ENV['RAILS'] || default_rails_version}"
 gem 'activeadmin', "~> #{ENV['AA'] || default_activeadmin_version}"
-
-if Gem::Version.new(rails_version) >= Gem::Version.new('8.0.0')
-  gem 'propshaft'
-else
-  gem 'sprockets-rails'
-  gem 'sass-rails'
-end
+gem 'sprockets-rails'
+gem 'sass-rails'
 
 group :test do
   gem 'simplecov', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,16 @@ gemspec
 default_rails_version = '7.1.0'
 default_activeadmin_version = '3.2.0'
 
-gem 'rails', "~> #{ENV['RAILS'] || default_rails_version}"
+rails_version = ENV['RAILS'] || default_rails_version
+gem 'rails', "~> #{rails_version}"
 gem 'activeadmin', "~> #{ENV['AA'] || default_activeadmin_version}"
-gem 'sprockets-rails'
-gem 'sass-rails'
+
+if Gem::Version.new(rails_version) >= Gem::Version.new('8.0.0')
+  gem 'propshaft'
+else
+  gem 'sprockets-rails'
+  gem 'sass-rails'
+end
 
 group :test do
   gem 'simplecov', require: false

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -1,3 +1,5 @@
+create_file "app/assets/config/manifest.js", skip: true
+
 generate :model, 'author name:string{10}:uniq last_name:string birthday:date --force'
 generate :model, 'post title:string:uniq body:text author:references --force'
 


### PR DESCRIPTION
Exclude AA 3.2.0 from Rails 8 as it predates Rails 8 support.