### PR TITLE
Added support of Active Admin v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,13 @@ jobs:
         exclude:
           - rails: '8.0.0'
             activeadmin: '3.2.0'
+        include:
+          - ruby: '3.4'
+            rails: '7.2.0'
+            activeadmin: '4.0.0.beta22'
+          - ruby: '3.4'
+            rails: '8.0.0'
+            activeadmin: '4.0.0.beta22'
     env:
       RAILS: ${{ matrix.rails }}
       AA: ${{ matrix.activeadmin }}
@@ -31,6 +38,17 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+      - name: Setup Node (AA v4 only)
+        if: matrix.activeadmin == '4.0.0.beta22'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: AA v4 environment summary
+        if: matrix.activeadmin == '4.0.0.beta22'
+        run: |
+          bundle exec gem list activeadmin
+          bundle info activeadmin
+          node --version
       - name: Run tests
         run: bundle exec rspec spec
   test-mysql:
@@ -96,6 +114,47 @@ jobs:
         with:
           ruby-version: '3.4'
           bundler-cache: true
+      - name: Run tests
+        run: bundle exec rspec spec
+  test-postgres-aa4:
+    name: Ruby 3.4 / Rails 8.0.0 / AA 4.0.0.beta22 / PostgreSQL 16
+    runs-on: ubuntu-latest
+    env:
+      RAILS: '8.0.0'
+      AA: '4.0.0.beta22'
+      DB: postgres
+      DB_HOST: 127.0.0.1
+      DB_PORT: 5432
+      DB_USERNAME: postgres
+      DB_PASSWORD: postgres
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: active_admin_import_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: AA v4 environment summary
+        run: |
+          bundle exec gem list activeadmin
+          bundle info activeadmin
+          node --version
       - name: Run tests
         run: bundle exec rspec spec
   coverage:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,17 +38,11 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: Setup Node (AA v4 only)
-        if: matrix.activeadmin == '4.0.0.beta22'
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
       - name: AA v4 environment summary
         if: matrix.activeadmin == '4.0.0.beta22'
         run: |
           bundle exec gem list activeadmin
           bundle info activeadmin
-          node --version
       - name: Run tests
         run: bundle exec rspec spec
   test-mysql:
@@ -147,14 +141,10 @@ jobs:
         with:
           ruby-version: '3.4'
           bundler-cache: true
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
       - name: AA v4 environment summary
         run: |
           bundle exec gem list activeadmin
           bundle info activeadmin
-          node --version
       - name: Run tests
         run: bundle exec rspec spec
   coverage:

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,4 @@ group :test do
   end
   gem 'database_cleaner'
   gem 'capybara'
-  gem 'cuprite'
-  gem 'webrick', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,22 @@ gemspec
 default_rails_version = '7.1.0'
 default_activeadmin_version = '3.2.0'
 
+# `~> 4.0.0.beta22` would admit 4.0.0 GA — pin prereleases exactly so the
+# CI cell tests the AA build it claims to test.
+aa_version = ENV['AA'] || default_activeadmin_version
+aa_op = aa_version.match?(/[a-z]/) ? '=' : '~>'
+
 gem 'rails', "~> #{ENV['RAILS'] || default_rails_version}"
-gem 'activeadmin', "~> #{ENV['AA'] || default_activeadmin_version}"
-gem 'sprockets-rails'
-gem 'sass-rails'
+gem 'activeadmin', "#{aa_op} #{aa_version}"
+
+if ENV['AA']&.start_with?('4')
+  # AA 4 uses Tailwind + importmap; sass-rails conflicts with Tailwind v4.
+  gem 'cssbundling-rails'
+  gem 'importmap-rails'
+else
+  gem 'sprockets-rails'
+  gem 'sass-rails'
+end
 
 group :test do
   gem 'simplecov', require: false

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Tool                    | Description
 :error_limit            |Limit the number of errors reported (default `5`, set to `nil` for all)
 :headers_rewrites       |hash with key (csv header) - value (db column name) rows mapping
 :if                     |Controls whether the 'Import' button is displayed. It supports a proc to be evaluated into a boolean value within the activeadmin render context.
+:action_item_html_options |HTML options passed to the index-page "Import …" action_item link. Defaults to `{ class: 'action-item-button' }` so the link matches AA 4's built-in action_items; the class is a no-op on AA 3. Override to drop the class or add your own (`{ class: 'my-btn' }`, `{ class: '', data: { turbo: false } }`, etc.).
 
 
 

--- a/active_admin_import.gemspec
+++ b/active_admin_import.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'activerecord-import', '>= 2.0'
   gem.add_runtime_dependency 'rchardet', '>= 1.6'
   gem.add_runtime_dependency 'rubyzip', '>= 1.2'
-  gem.add_dependency 'activeadmin', '>= 3.0', '< 4.0'
+  gem.add_dependency 'activeadmin', '>= 3.0', '< 5.0'
 end

--- a/active_admin_import.gemspec
+++ b/active_admin_import.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'activerecord-import', '>= 2.0'
   gem.add_runtime_dependency 'rchardet', '>= 1.6'
   gem.add_runtime_dependency 'rubyzip', '>= 1.2'
-  gem.add_dependency 'activeadmin', '>= 3.0', '< 5.0'
+  gem.add_dependency 'activeadmin', '>= 3.0', '< 4.1'
 end

--- a/lib/active_admin_import/dsl.rb
+++ b/lib/active_admin_import/dsl.rb
@@ -27,6 +27,8 @@ module ActiveAdminImport
   module DSL
     CONTEXT_METHOD = :active_admin_import_context
 
+    ACTIVE_ADMIN_V4 = Gem::Version.new(ActiveAdmin::VERSION).segments.first >= 4
+
     def self.prepare_import_model(template_object, controller, params: nil)
       model = template_object.is_a?(Proc) ? template_object.call : template_object
       if params
@@ -45,9 +47,7 @@ module ActiveAdminImport
       model_name = options[:resource_label].downcase
       plural_model_name = options[:plural_resource_label].downcase
       if result.empty?
-        # AA 4's flash partial only renders error/alert/notice, so use :alert
-        # instead of :warning to stay cross-compatible with AA 3.
-        flash[:alert] = I18n.t('active_admin_import.file_empty_error')
+        flash[ACTIVE_ADMIN_V4 ? :alert : :warning] = I18n.t('active_admin_import.file_empty_error')
       else
         if result.failed?
           flash[:error] = I18n.t(

--- a/lib/active_admin_import/dsl.rb
+++ b/lib/active_admin_import/dsl.rb
@@ -45,7 +45,9 @@ module ActiveAdminImport
       model_name = options[:resource_label].downcase
       plural_model_name = options[:plural_resource_label].downcase
       if result.empty?
-        flash[:warning] = I18n.t('active_admin_import.file_empty_error')
+        # AA 4's flash partial only renders error/alert/notice, so use :alert
+        # instead of :warning to stay cross-compatible with AA 3.
+        flash[:alert] = I18n.t('active_admin_import.file_empty_error')
       else
         if result.failed?
           flash[:error] = I18n.t(
@@ -81,7 +83,8 @@ module ActiveAdminImport
         if authorized?(ActiveAdminImport::Auth::IMPORT, active_admin_config.resource_class)
           link_to(
             I18n.t('active_admin_import.import_model', plural_model: options[:plural_resource_label]),
-            action: :import
+            { action: :import },
+            options[:action_item_html_options]
           )
         end
       end

--- a/lib/active_admin_import/dsl.rb
+++ b/lib/active_admin_import/dsl.rb
@@ -27,7 +27,7 @@ module ActiveAdminImport
   module DSL
     CONTEXT_METHOD = :active_admin_import_context
 
-    ACTIVE_ADMIN_V4 = Gem::Version.new(ActiveAdmin::VERSION).segments.first >= 4
+    ACTIVE_ADMIN_V4 = Gem::Version.new(ActiveAdmin::VERSION) >= Gem::Version.new('4.0.0.beta1')
 
     def self.prepare_import_model(template_object, controller, params: nil)
       model = template_object.is_a?(Proc) ? template_object.call : template_object

--- a/lib/active_admin_import/options.rb
+++ b/lib/active_admin_import/options.rb
@@ -22,7 +22,8 @@ module ActiveAdminImport
       :plural_resource_label,
       :error_limit,
       :headers_rewrites,
-      :if
+      :if,
+      :action_item_html_options
     ].freeze
 
     def self.options_for(config, options = {})
@@ -39,7 +40,10 @@ module ActiveAdminImport
         plural_resource_label: config.plural_resource_label,
         error_limit: 5,
         headers_rewrites: {},
-        if: true
+        if: true,
+        # AA 4's built-in action_items hardcode this class for Tailwind styling
+        # (lib/active_admin/resource/action_items.rb). It's a no-op on AA 3.
+        action_item_html_options: { class: 'action-item-button' }
       }.deep_merge(options)
     end
   end

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -41,8 +41,8 @@ describe 'import', type: :feature do
   end
 
   def upload_file!(name, ext = 'csv')
-    attach_file('active_admin_import_model_file', File.expand_path("./spec/fixtures/files/#{name}.#{ext}"))
-    find_button('Import').click
+    attach_file(ImportFormSelectors.file_input_id, File.expand_path("./spec/fixtures/files/#{name}.#{ext}"))
+    find_button(ImportFormSelectors.import_button_text).click
   end
 
   context 'posts index' do
@@ -118,7 +118,7 @@ describe 'import', type: :feature do
             # reload page
             visit '/admin/posts/import'
             # submit form without file
-            find_button('Import').click
+            find_button(ImportFormSelectors.import_button_text).click
           end
 
           it 'should render validation error' do
@@ -171,7 +171,7 @@ describe 'import', type: :feature do
       # TODO: removing this causes  undefined method `ransack' for #<ActiveRecord::Relation []>
       allow_any_instance_of(Admin::AuthorsController).to receive(:find_collection).and_return(Author.all)
       visit '/admin/authors'
-      find_link('Import Authors').click
+      find_link(ImportFormSelectors.import_link_text).click
       expect(current_path).to eq('/admin/authors/import')
     end
   end
@@ -228,14 +228,14 @@ describe 'import', type: :feature do
     end
 
     it 'has valid form' do
-      form = find('#new_active_admin_import_model')
+      form = find(ImportFormSelectors.form_css)
       expect(form['action']).to eq('/admin/authors/do_import')
       expect(form['enctype']).to eq('multipart/form-data')
-      file_input = form.find('input#active_admin_import_model_file')
+      file_input = form.find(ImportFormSelectors.file_input_css)
       expect(file_input[:type]).to eq('file')
       expect(file_input.value).to be_blank
-      submit_input = form.find('#active_admin_import_model_submit_action input')
-      expect(submit_input[:value]).to eq('Import')
+      submit_input = form.find(ImportFormSelectors.submit_css)
+      expect(submit_input[:value]).to eq(ImportFormSelectors.import_button_text)
       expect(submit_input[:type]).to eq('submit')
     end
 
@@ -261,7 +261,7 @@ describe 'import', type: :feature do
 
       context 'when no file' do
         it 'should render error' do
-          find_button('Import').click
+          find_button(ImportFormSelectors.import_button_text).click
           expect(Author.count).to eq(0)
           expect(page).to have_content I18n.t('active_admin_import.no_file_error')
         end
@@ -605,7 +605,7 @@ describe 'import', type: :feature do
 
       # Second submission without selecting a file
       expect do
-        find_button('Import').click
+        find_button(ImportFormSelectors.import_button_text).click
         expect(page).to have_content(I18n.t('active_admin_import.no_file_error'))
       end.not_to change { Author.count }
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,9 +12,9 @@ Bundler.setup
 
 ENV['RAILS_ENV'] = 'test'
 require 'rails'
+require 'test_app_paths'
 ENV['RAILS'] = Rails.version
-ENV['DB'] ||= 'sqlite'
-ENV['RAILS_ROOT'] = File.expand_path("../rails/rails-#{ENV['RAILS']}-#{ENV['DB']}", __FILE__)
+ENV['RAILS_ROOT'] = TestAppPaths.app_root
 system 'rake setup' unless File.exist?(ENV['RAILS_ROOT'])
 
 require 'active_model'
@@ -31,30 +31,15 @@ require 'support/admin'
 require 'support/import_form_selectors'
 require 'capybara/rails'
 require 'capybara/rspec'
-require 'capybara/cuprite'
 
-Capybara.server = :webrick
-Capybara.register_driver :cuprite do |app|
-  Capybara::Cuprite::Driver.new(app, headless: true, window_size: [1280, 800])
-end
-Capybara.javascript_driver = :cuprite
-Capybara.default_max_wait_time = 5
+# Specs exercise ActiveAdmin through Capybara's default rack_test driver — no
+# JavaScript or real browser is needed, so no Cuprite/Chrome or app server.
+Capybara.default_driver = :rack_test
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = false
 
   config.before(:suite) do
-    # Cuprite races the Tailwind build under AA 4 (no CSS → unstyled DOM →
-    # selector failures that look like DOM-ID drift). Rebuild before the
-    # suite and abort if nothing landed, so the failure mode is legible.
-    if Gem::Version.new(ActiveAdmin::VERSION) >= Gem::Version.new('4')
-      rails_root = ENV['RAILS_ROOT']
-      ok = system('npm run build:css', chdir: rails_root)
-      built = Dir.glob(File.join(rails_root, 'app/assets/builds/*.css'))
-                 .find { |p| File.size?(p).to_i.positive? }
-      abort "[AA4] Tailwind build produced no CSS in #{rails_root} (npm ok=#{ok})" unless built
-    end
-
     ActiveRecord::Migration.maintain_test_schema!
     DatabaseCleaner.strategy = :truncation
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,7 @@ ActiveAdmin.application.current_user_method = false
 
 require 'rspec/rails'
 require 'support/admin'
+require 'support/import_form_selectors'
 require 'capybara/rails'
 require 'capybara/rspec'
 require 'capybara/cuprite'
@@ -43,6 +44,17 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 
   config.before(:suite) do
+    # Cuprite races the Tailwind build under AA 4 (no CSS → unstyled DOM →
+    # selector failures that look like DOM-ID drift). Rebuild before the
+    # suite and abort if nothing landed, so the failure mode is legible.
+    if Gem::Version.new(ActiveAdmin::VERSION) >= Gem::Version.new('4')
+      rails_root = ENV['RAILS_ROOT']
+      ok = system('npm run build:css', chdir: rails_root)
+      built = Dir.glob(File.join(rails_root, 'app/assets/builds/*.css'))
+                 .find { |p| File.size?(p).to_i.positive? }
+      abort "[AA4] Tailwind build produced no CSS in #{rails_root} (npm ok=#{ok})" unless built
+    end
+
     ActiveRecord::Migration.maintain_test_schema!
     DatabaseCleaner.strategy = :truncation
     DatabaseCleaner.clean_with(:truncation)

--- a/spec/support/import_form_selectors.rb
+++ b/spec/support/import_form_selectors.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Selectors for the import form. Formtastic 6 (AA 4) keeps the same DOM IDs
+# as Formtastic 4 (AA 3) for our form shape, so the selectors are version
+# independent today. If a future AA release shifts an ID, branch here.
+module ImportFormSelectors
+  module_function
+
+  SELECTORS = {
+    form_id: 'new_active_admin_import_model',
+    file_input_id: 'active_admin_import_model_file',
+    file_input_css: 'input#active_admin_import_model_file',
+    submit_css: '#active_admin_import_model_submit_action input',
+    import_button_text: 'Import',
+    import_link_text: 'Import Authors'
+  }.freeze
+
+  def form_id            = SELECTORS[:form_id]
+  def form_css           = "##{form_id}"
+  def file_input_id      = SELECTORS[:file_input_id]
+  def file_input_css     = SELECTORS[:file_input_css]
+  def submit_css         = SELECTORS[:submit_css]
+  def import_button_text = SELECTORS[:import_button_text]
+  def import_link_text   = SELECTORS[:import_link_text]
+end

--- a/spec/support/import_form_selectors.rb
+++ b/spec/support/import_form_selectors.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
-# Selectors for the import form. Formtastic 6 (AA 4) keeps the same DOM IDs
-# as Formtastic 4 (AA 3) for our form shape, so the selectors are version
-# independent today. If a future AA release shifts an ID, branch here.
+# Formtastic 6 (AA 4) keeps the same DOM IDs as Formtastic 4 (AA 3) for this
+# form, so one selector set serves both — branch here if a future AA shifts an ID.
 module ImportFormSelectors
   module_function
 

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -50,8 +50,28 @@ gsub_file "config/environment.rb",
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
+aa_v4 = ENV['AA']&.start_with?('4')
+
 generate :'active_admin:install --skip-users'
-generate :'formtastic:install'
+
+if aa_v4
+  # AA 4 ships Formtastic 6 and its own Tailwind config via
+  # `active_admin:assets`; npm wiring is on the host.
+  generate :'active_admin:assets'
+  create_file 'package.json', <<~JSON
+    {
+      "private": true,
+      "scripts": {
+        "build:css": "tailwindcss -i ./app/assets/stylesheets/active_admin.css -o ./app/assets/builds/active_admin.css --minify"
+      }
+    }
+  JSON
+  run 'mkdir -p app/assets/builds'
+  run 'npm install @activeadmin/activeadmin@4.0.0-beta22 @tailwindcss/cli'
+  run 'npm run build:css'
+else
+  generate :'formtastic:install'
+end
 
 run 'rm -rf test'
 route "root :to => 'admin/dashboard#index'"

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -55,20 +55,11 @@ aa_v4 = ENV['AA']&.start_with?('4')
 generate :'active_admin:install --skip-users'
 
 if aa_v4
-  # AA 4 ships Formtastic 6 and its own Tailwind config via
-  # `active_admin:assets`; npm wiring is on the host.
+  # `active_admin:assets` swaps AA 3's Sprockets SCSS/JS for AA 4's Tailwind CSS
+  # stub. We don't compile it — specs assert on DOM and flash text, not styling,
+  # so the stub suffices and no Node is needed. `builds/` satisfies cssbundling-rails.
   generate :'active_admin:assets'
-  create_file 'package.json', <<~JSON
-    {
-      "private": true,
-      "scripts": {
-        "build:css": "tailwindcss -i ./app/assets/stylesheets/active_admin.css -o ./app/assets/builds/active_admin.css --minify"
-      }
-    }
-  JSON
   run 'mkdir -p app/assets/builds'
-  run 'npm install @activeadmin/activeadmin@4.0.0-beta22 @tailwindcss/cli'
-  run 'npm run build:css'
 else
   generate :'formtastic:install'
 end

--- a/spec/support/test_app_paths.rb
+++ b/spec/support/test_app_paths.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module TestAppPaths
+  module_function
+
+  def app_dir_name
+    "rails-#{Rails::VERSION::STRING}-#{ENV['DB'] || 'sqlite'}-aa#{ENV['AA'] || 'default'}"
+  end
+
+  # Absolute path under spec/rails/, used as RAILS_ROOT.
+  def app_root
+    File.expand_path("../rails/#{app_dir_name}", __dir__)
+  end
+end

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -8,6 +8,16 @@ task :setup do
              when 'postgres', 'postgresql' then 'postgresql'
              else 'sqlite3'
              end
+  aa_v4 = ENV['AA']&.start_with?('4')
+
+  puts "[setup] ActiveAdmin: #{ENV['AA'] || '(Gemfile default)'} / Rails: #{Rails::VERSION::STRING} / DB: #{rails_db}"
+
+  if aa_v4
+    %w[node npm].each do |bin|
+      abort "[setup] AA v4 needs `#{bin}` on PATH for the Tailwind build" unless system("command -v #{bin} > /dev/null 2>&1")
+    end
+    puts "[setup] node: #{`node --version`.strip} / npm: #{`npm --version`.strip}"
+  end
 
   rails_new_opts = %W(
     --skip-turbolinks
@@ -17,5 +27,9 @@ task :setup do
     -m
     spec/support/rails_template.rb
   )
+  # v4 drops sprockets-rails (see Gemfile), so skip the asset pipeline to
+  # avoid the auto-generated `config/initializers/assets.rb` crashing at boot.
+  rails_new_opts.unshift('--skip-asset-pipeline') if aa_v4
+
   system "bundle exec rails new spec/rails/rails-#{Rails::VERSION::STRING}-#{db} #{rails_new_opts.join(' ')}"
 end

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -1,3 +1,5 @@
+require_relative '../spec/support/test_app_paths'
+
 desc "Creates a test rails app for the specs to run against"
 task :setup do
   require 'rails/version'
@@ -12,13 +14,6 @@ task :setup do
 
   puts "[setup] ActiveAdmin: #{ENV['AA'] || '(Gemfile default)'} / Rails: #{Rails::VERSION::STRING} / DB: #{rails_db}"
 
-  if aa_v4
-    %w[node npm].each do |bin|
-      abort "[setup] AA v4 needs `#{bin}` on PATH for the Tailwind build" unless system("command -v #{bin} > /dev/null 2>&1")
-    end
-    puts "[setup] node: #{`node --version`.strip} / npm: #{`npm --version`.strip}"
-  end
-
   rails_new_opts = %W(
     --skip-turbolinks
     --skip-spring
@@ -31,5 +26,5 @@ task :setup do
   # avoid the auto-generated `config/initializers/assets.rb` crashing at boot.
   rails_new_opts.unshift('--skip-asset-pipeline') if aa_v4
 
-  system "bundle exec rails new spec/rails/rails-#{Rails::VERSION::STRING}-#{db} #{rails_new_opts.join(' ')}"
+  system "bundle exec rails new spec/rails/#{TestAppPaths.app_dir_name} #{rails_new_opts.join(' ')}"
 end


### PR DESCRIPTION
## Summary

Adds support for **ActiveAdmin 4** (tested against `4.0.0.beta22`) alongside the existing AA 3 support. The gem stays a pure-Ruby dependency — `active_admin_import` gains **no Node/npm dependency**, and neither does its test suite: Tailwind asset compilation is owned entirely by ActiveAdmin in host apps.

The dependency range widens to `>= 3.0, < 4.1` and the test matrix gains AA 4 cells (SQLite + PostgreSQL).

## Why

ActiveAdmin 4 moves from Sprockets/Sass to Tailwind + importmap and ships Formtastic 6. Two things needed to change for the import flow to work under AA 4 while staying compatible with AA 3:

1. **Flash type.** AA 4's flash partial only renders `error` / `alert` / `notice` — a `flash[:warning]` is silently dropped (see [`_flash_messages.html.erb`](https://github.com/activeadmin/activeadmin/blob/master/app/views/active_admin/_flash_messages.html.erb)). The empty-file message picks the key by AA version: `:alert` on AA 4, `:warning` on AA 3 — so AA 3 behavior is unchanged and AA 4 renders correctly.
2. **Action-item styling hook.** AA 4's built-in `action_item` links carry a Tailwind class. The import link now accepts HTML options so it can match.

## Changes

### Library
- **`lib/active_admin_import/dsl.rb`** — empty-file message uses `flash[:alert]` on AA 4 and `flash[:warning]` on AA 3 (no behavior change for AA 3). The index "Import …" `action_item` link now forwards `:action_item_html_options` to `link_to`.
- **`lib/active_admin_import/options.rb`** — new `:action_item_html_options` option, defaulting to `{ class: 'action-item-button' }` (the class AA 4 hardcodes for its action items; a no-op on AA 3).
- **`README.md`** — documents the new `:action_item_html_options` option in the options table.

### Dependency
- **`active_admin_import.gemspec`** — widens `activeadmin` from `>= 3.0, < 4.0` to `>= 3.0, < 4.1`.
  - The cap matches the **tested ceiling (`4.0.0.beta22`)**. Bumping it to admit AA 4.1+ should come with a matching CI cell for that release.

### CI / test harness
- **`.github/workflows/test.yml`** — adds AA `4.0.0.beta22` matrix rows (Rails 7.2 / 8.0), plus a dedicated PostgreSQL 16 + AA 4 job. No Node setup needed.
- **`Gemfile`** — on AA 4, loads `cssbundling-rails` + `importmap-rails` instead of `sprockets-rails` + `sass-rails` (Tailwind v4 conflicts with sass-rails); pins AA prerelease versions exactly so each CI cell tests the build it claims to.
- **`spec/support/rails_template.rb`** — on AA 4, runs `active_admin:assets` (swaps the Sprockets SCSS/JS for AA 4's Tailwind CSS stub). No Tailwind compile: the specs assert on DOM structure and flash text, not visual styling, so an unstyled stub suffices and the suite stays Node-free.
- **`tasks/test.rake`** / **`spec/spec_helper.rb`** / **`spec/support/test_app_paths.rb`** (new) — skip the asset pipeline when generating the AA 4 test app, and key the cached app on the AA version via a shared helper (`rails-<rails>-<db>-aa<aa>`) so AA 3 and AA 4 apps — which generate structurally different apps — no longer collide in one cache slot.
- **`spec/support/import_form_selectors.rb`** (new) — centralizes the import-form DOM selectors so specs are not littered with literal IDs; AA 3 and AA 4 share the same selectors today.
- **`spec/import_spec.rb`** — specs reference the shared selectors instead of inline strings.
- **`Gemfile`** / **`spec/spec_helper.rb`** — removes the unused `cuprite` + `webrick` test dependencies and pins Capybara to its `rack_test` driver explicitly. No spec uses a JavaScript / real-browser driver (none are tagged `js: true`), so the suite needs neither Chrome nor a running app server.

## Test plan

- [x] Full spec suite green on AA 3 (SQLite).
- [x] AA `4.0.0.beta22` matrix cells green (Rails 7.2 / 8.0, SQLite).
- [x] AA `4.0.0.beta22` + PostgreSQL 16 job green.
- [x] Existing MySQL / PostgreSQL AA 3 jobs unaffected.

## Follow-up

- Re-test against ActiveAdmin **4.0 GA** when released and bump the `< 4.1` cap (with a matching CI cell).
- Tailwind styling polish for the import view under AA 4 — out of scope here; the specs are style-agnostic, but a host app would want the compiled CSS.
- Optional CI cleanup: collapse the AA 3 and AA 4 PostgreSQL jobs into a single `AA`-matrixed PostgreSQL job to cut duplication.
- Version bump intentionally left to the maintainer (no `version.rb` change in this MR).
