### PR TITLE
Support updating records by id via :on_duplicate_key_update (#187)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ update colliding rows and insert new ones in a single pass with
 
 ```ruby
 ActiveAdmin.register Author do
+  # PostgreSQL / SQLite
   active_admin_import validate: false,
                       on_duplicate_key_update: {
                         conflict_target: [:id],
@@ -251,8 +252,16 @@ end
 
 Notes:
 
-* `conflict_target` names the unique column(s) used to detect a collision
-  (`[:id]` for the primary key). MySQL infers it and ignores this option.
+* The option shape is **adapter-specific**, since it is passed straight to
+  `activerecord-import`:
+  * PostgreSQL / SQLite need an explicit `:conflict_target` — the unique
+    column(s) used to detect a collision (`[:id]` for the primary key).
+  * MySQL infers the conflicting key, so pass just the column list and omit
+    `:conflict_target` (passing it raises `Unknown column 'conflict_target'`):
+
+    ```ruby
+    on_duplicate_key_update: %i[name last_name birthday]
+    ```
 * Turn `validate` off for id-based upserts. `activerecord-import` runs
   uniqueness validations against the very rows the upsert is about to overwrite,
   so a model-level `validates_uniqueness_of` would otherwise reject the update.

--- a/README.md
+++ b/README.md
@@ -235,7 +235,28 @@ ActiveAdmin.register Post do
 end
 ```
 
-For databases that support upserts you can use `:on_duplicate_key_update` instead.
+On databases that support upserts (MySQL, PostgreSQL 9.5+, SQLite 3.24+) you can
+update colliding rows and insert new ones in a single pass with
+`:on_duplicate_key_update` — no `delete_all` required:
+
+```ruby
+ActiveAdmin.register Author do
+  active_admin_import validate: false,
+                      on_duplicate_key_update: {
+                        conflict_target: [:id],
+                        columns: %i[name last_name birthday]
+                      }
+end
+```
+
+Notes:
+
+* `conflict_target` names the unique column(s) used to detect a collision
+  (`[:id]` for the primary key). MySQL infers it and ignores this option.
+* Turn `validate` off for id-based upserts. `activerecord-import` runs
+  uniqueness validations against the very rows the upsert is about to overwrite,
+  so a model-level `validates_uniqueness_of` would otherwise reject the update.
+* Active Record callbacks are not fired for bulk imports.
 
 ##### Tune batch size
 

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -217,6 +217,44 @@ describe 'import', type: :feature do
         expect(Author.find(2).name).to eq('Jane')
       end
     end
+
+    # Issue #187: update existing records by id without a delete_all workaround.
+    # On databases that support upserts, :on_duplicate_key_update lets a single
+    # import update colliding rows and insert new ones in one pass.
+    context 'upserting authors by id via :on_duplicate_key_update' do
+      before do
+        # Existing row shares its id with the first CSV row but carries a stale
+        # birthday; the second CSV row (id 2) has no match and must be inserted.
+        Author.delete_all
+        Author.create!(id: 1, name: 'John', last_name: 'Doe', birthday: '1900-01-01')
+
+        add_author_resource(
+          # Uniqueness validation runs against the rows the upsert is about to
+          # overwrite, so it must be off for an id-based upsert (see README).
+          validate: false,
+          on_duplicate_key_update: {
+            conflict_target: [:id],
+            columns: %i[name last_name birthday]
+          }
+        )
+        visit '/admin/authors/import'
+        upload_file!(:authors_with_ids)
+      end
+
+      it 'reports every row as imported' do
+        expect(page).to have_content 'Successfully imported 2 authors'
+      end
+
+      it 'updates the existing author instead of duplicating it' do
+        expect(Author.count).to eq(2)
+        expect(Author.find(1).birthday).to eq(Date.new(1986, 5, 1))
+      end
+
+      it 'inserts the non-colliding author' do
+        expect(Author.find(2).name).to eq('Jane')
+        expect(Author.find(2).last_name).to eq('Roe')
+      end
+    end
   end
 
   context 'with valid options' do

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -228,14 +228,21 @@ describe 'import', type: :feature do
         Author.delete_all
         Author.create!(id: 1, name: 'John', last_name: 'Doe', birthday: '1900-01-01')
 
+        # The option shape is adapter-specific: MySQL infers the conflicting key
+        # and only wants the column list, while PostgreSQL/SQLite need an explicit
+        # :conflict_target (see README).
+        on_duplicate_key_update =
+          if ActiveRecord::Base.connection.adapter_name.match?(/mysql/i)
+            %i[name last_name birthday]
+          else
+            { conflict_target: [:id], columns: %i[name last_name birthday] }
+          end
+
         add_author_resource(
           # Uniqueness validation runs against the rows the upsert is about to
           # overwrite, so it must be off for an id-based upsert (see README).
           validate: false,
-          on_duplicate_key_update: {
-            conflict_target: [:id],
-            columns: %i[name last_name birthday]
-          }
+          on_duplicate_key_update: on_duplicate_key_update
         )
         visit '/admin/authors/import'
         upload_file!(:authors_with_ids)


### PR DESCRIPTION
Closes #187.

### Context

Issue #187 asked for a way to **update existing records based on an id column** during import, instead of only inserting. This is already achievable through `activerecord-import`'s upsert support (`:on_duplicate_key_update`), but the behaviour was **untested** and the README only mentioned it in passing ("For databases that support upserts you can use `:on_duplicate_key_update` instead.").

This PR proves it works and documents it properly.

### What's here

- **Spec** (`spec/import_spec.rb`): a new context under *authors already exist* that imports `authors_with_ids.csv` with

  ```ruby
  active_admin_import validate: false,
                      on_duplicate_key_update: { conflict_target: [:id], columns: %i[name last_name birthday] }
  ```

  and asserts that a single import:
  - updates the colliding row (id 1 — stale birthday replaced, no duplicate created),
  - inserts the non-colliding row (id 2),
  - reports `Successfully imported 2 authors`.

- **README**: replaced the one-line note with a concrete example and the two caveats that bite in practice:
  - `conflict_target` must name the unique column(s); MySQL infers and ignores it.
  - `validate` must be off for id-based upserts — `activerecord-import` runs uniqueness validations against the very rows the upsert is about to overwrite, so a model-level `validates_uniqueness_of` would reject the update (verified: with `validate: true` the existing-row update is dropped with "Last name has already been taken").
  - Active Record callbacks are not fired for bulk imports.

### Verification

`bundle exec rspec spec/import_spec.rb` → **52 examples, 0 failures** (3 new). Run locally on SQLite 3.53 / Rails 7.1 / Active Admin 3.2.