### PR TITLE
fix: raise a clear error on blank CSV column headers (#197)

### DIFF
--- a/lib/active_admin_import/importer.rb
+++ b/lib/active_admin_import/importer.rb
@@ -129,7 +129,14 @@ module ActiveAdminImport
     end
 
     def prepare_headers
-      headers = self.headers.present? ? self.headers.map(&:to_s) : yield
+      headers = self.headers.present? ? self.headers : yield
+      blank_positions = headers.each_index.select { |i| headers[i].to_s.strip.empty? }
+      unless blank_positions.empty?
+        raise ActiveAdminImport::Exception,
+              "blank column header at column #{blank_positions.map { |i| i + 1 }.join(', ')}"
+      end
+
+      headers = headers.map(&:to_s)
       @headers = Hash[headers.zip(headers.map { |el| el.underscore.gsub(/\s+/, '_') })].with_indifferent_access
       @headers.merge!(options[:headers_rewrites].symbolize_keys.slice(*@headers.symbolize_keys.keys))
       @headers

--- a/spec/fixtures/files/authors_blank_header_end.csv
+++ b/spec/fixtures/files/authors_blank_header_end.csv
@@ -1,0 +1,3 @@
+Name,Last name,Birthday,
+John,Doe,1986-05-01,x
+Jane,Roe,1988-11-16,y

--- a/spec/fixtures/files/authors_blank_header_middle.csv
+++ b/spec/fixtures/files/authors_blank_header_middle.csv
@@ -1,0 +1,3 @@
+Name,,Last name,Birthday
+John,x,Doe,1986-05-01
+Jane,y,Roe,1988-11-16

--- a/spec/fixtures/files/authors_empty_header.csv
+++ b/spec/fixtures/files/authors_empty_header.csv
@@ -1,0 +1,3 @@
+,Name,Last name,Birthday
+x,John,Doe,1986-05-01
+y,Jane,Roe,1988-11-16

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -190,6 +190,22 @@ describe 'import', type: :feature do
     end
   end
 
+  # Issue #197: a CSV with an empty header cell used to crash with
+  # `undefined method 'underscore' for nil`.
+  context 'with a blank column header' do
+    before do
+      add_author_resource
+      visit '/admin/authors/import'
+      upload_file!(:authors_empty_header)
+    end
+
+    it 'reports a clear error and imports nothing' do
+      expect(page).to have_content 'blank column header at column 1'
+      expect(page).to have_no_content 'undefined method'
+      expect(Author.count).to eq(0)
+    end
+  end
+
   context 'authors already exist' do
     before do
       Author.create!(id: 1, name: 'Jane', last_name: 'Roe')

--- a/spec/import_spec.rb
+++ b/spec/import_spec.rb
@@ -191,18 +191,32 @@ describe 'import', type: :feature do
   end
 
   # Issue #197: a CSV with an empty header cell used to crash with
-  # `undefined method 'underscore' for nil`.
+  # `undefined method 'underscore' for nil`, wherever the blank sits.
   context 'with a blank column header' do
-    before do
-      add_author_resource
-      visit '/admin/authors/import'
-      upload_file!(:authors_empty_header)
+    shared_examples 'a rejected blank header' do |fixture, column|
+      before do
+        add_author_resource
+        visit '/admin/authors/import'
+        upload_file!(fixture)
+      end
+
+      it 'reports a clear error and imports nothing' do
+        expect(page).to have_content "blank column header at column #{column}"
+        expect(page).to have_no_content 'undefined method'
+        expect(Author.count).to eq(0)
+      end
     end
 
-    it 'reports a clear error and imports nothing' do
-      expect(page).to have_content 'blank column header at column 1'
-      expect(page).to have_no_content 'undefined method'
-      expect(Author.count).to eq(0)
+    context 'at the beginning' do
+      it_behaves_like 'a rejected blank header', :authors_empty_header, 1
+    end
+
+    context 'in the middle' do
+      it_behaves_like 'a rejected blank header', :authors_blank_header_middle, 2
+    end
+
+    context 'at the end' do
+      it_behaves_like 'a rejected blank header', :authors_blank_header_end, 4
     end
   end
 


### PR DESCRIPTION
Closes #197.

### Problem

A CSV whose header row contains an empty cell — e.g. a stray leading comma from a spreadsheet export:

```
,Name,Last name,Birthday
x,John,Doe,1986-05-01
```

parses the first header as `nil`, and `prepare_headers` crashed on `nil.underscore`:

```
Error: undefined method 'underscore' for nil
```

The fix suggested in the issue (coercing headers with `to_s`) does **not** resolve it — it only moves the failure to import time, because an unnamed `""` column maps to no attribute:

```
Error: Missing column for value <> at index 0
```

### Fix

Detect blank header cells up front and raise an `ActiveAdminImport::Exception` naming the offending column (1‑based). That exception is already rescued by the import action, so the user sees an actionable flash instead of a `NoMethodError`:

```
Error: blank column header at column 1
```

This is the **option B** behaviour (fail with a clear message) rather than silently dropping unnamed columns — a stray comma shouldn't quietly discard data.

### Tests

New `with a blank column header` context: uploads a fixture with an empty leading header, asserts the clear error, that no `NoMethodError` leaks, and that nothing is imported.

Full suite green locally on Ruby 3.3 / Rails 8.1.3 / AA 3.5.1 / SQLite — 62 examples, 0 failures.
