### PR TITLE
Release 8.0.0

### DIFF
--- a/lib/active_admin_import/version.rb
+++ b/lib/active_admin_import/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveAdminImport
-  VERSION = '7.0.0'
+  VERSION = '8.0.0'
 end


### PR DESCRIPTION
Release **8.0.0**.

Major bump because the minimum Ruby is raised and EOL runtimes are dropped.

### Breaking changes
- Require **Ruby >= 3.3** — Ruby 3.1/3.2 are EOL and no longer supported (#221).
- Drop EOL **Rails 7.1** from the supported/tested matrix (Rails 7.2 / 8.0 / 8.1 are tested) (#221).

### Features
- Update existing records by id in a single import via `:on_duplicate_key_update` — upsert without a `delete_all` workaround (#187, #220).

### Fixes
- `batch_slice_columns` now composes when called more than once: successive calls progressively narrow the column set instead of corrupting values (#186, #223).
- A blank CSV column header now raises a clear `ActiveAdminImport::Exception` (`blank column header at column N`) instead of crashing with `undefined method 'underscore' for nil` (#197, #224).

### Internal / docs
- CI now covers **Ruby 4.0** and **Rails 8.1**; the AA 3 test app is generated with `--skip-javascript` to stay compatible with Rails 8.1 (#221).
- README: documented the two id-update strategies (native upsert vs delete-then-insert) (#222).

---

This PR only bumps the version to 8.0.0. Tag `v8.0.0`, the GitHub release and the RubyGems publish follow once merged.
